### PR TITLE
Fix OSM commands for the western hemisphere

### DIFF
--- a/src/modules/OSMcommand.js
+++ b/src/modules/OSMcommand.js
@@ -61,7 +61,7 @@ function findS (points) {
 function findN (points) {
   // Find maximum point (north)
   let s = [0, 0]
-  let max = Number.MIN_VALUE
+  let max = Number.NEGATIVE_INFINITY
   for (let i = 0; i < points.length; i++) {
     const norm = points[i][0] + points[i][1]
     if (norm > max) {


### PR DESCRIPTION
The OSMcommand library was unintentionally bounding the minimum at `[0,0]`.
When the location for the OSM command (such as 'rails') was in the western
hemisphere (ie, a negative number), the calculation for the 'minimum'
coordinates would be improperly calculated, leading to a faulty request
to the OpenStreetMap API, which would respond with a 400 error.

Fix it by bounding the minimum value at the most negative number.

Fixes: #10